### PR TITLE
Handle rotation

### DIFF
--- a/GBInfiniteScrollView/GBInfiniteScrollView/GBInfiniteScrollView.m
+++ b/GBInfiniteScrollView/GBInfiniteScrollView/GBInfiniteScrollView.m
@@ -1128,6 +1128,7 @@ static CGFloat const GBAutoScrollDefaultInterval = 3.0f;
     
     CGRect frame = [page frame];
     frame.origin.x = pointX;
+    frame.size = self.frame.size;
     page.frame = frame;
     
     [self addSubview:page];
@@ -1141,6 +1142,7 @@ static CGFloat const GBAutoScrollDefaultInterval = 3.0f;
     
     CGRect frame = [page frame];
     frame.origin.y = pointY;
+    frame.size = self.frame.size;
     page.frame = frame;
     
     [self addSubview:page];
@@ -1154,6 +1156,7 @@ static CGFloat const GBAutoScrollDefaultInterval = 3.0f;
     
     CGRect frame = [page frame];
     frame.origin.x = rightEdge;
+    frame.size = self.frame.size;
     page.frame = frame;
     
     [self addSubview:page];
@@ -1170,6 +1173,7 @@ static CGFloat const GBAutoScrollDefaultInterval = 3.0f;
     
     CGRect frame = [page frame];
     frame.origin.y = bottomEdge;
+    frame.size = self.frame.size;
     page.frame = frame;
     
     [self addSubview:page];
@@ -1186,6 +1190,7 @@ static CGFloat const GBAutoScrollDefaultInterval = 3.0f;
     
     CGRect frame = [page frame];
     frame.origin.x = leftEdge - [self pageWidth];
+    frame.size = self.frame.size;
     page.frame = frame;
     
     [self addSubview:page];
@@ -1202,6 +1207,7 @@ static CGFloat const GBAutoScrollDefaultInterval = 3.0f;
     
     CGRect frame = [page frame];
     frame.origin.y = topEdge - [self pageHeight];
+    frame.size = self.frame.size;
     page.frame = frame;
     
     [self addSubview:page];

--- a/GBInfiniteScrollView/GBInfiniteScrollView/GBInfiniteScrollViewPage.m
+++ b/GBInfiniteScrollView/GBInfiniteScrollView/GBInfiniteScrollViewPage.m
@@ -10,6 +10,13 @@
 
 CGFloat const GBInfiniteScrollViewPageMargin = 16.0f;
 
+UIViewAutoresizing const GBInfiniteScrollViewPageResizeAll = UIViewAutoresizingFlexibleLeftMargin |
+                                                             UIViewAutoresizingFlexibleWidth |
+                                                             UIViewAutoresizingFlexibleRightMargin |
+                                                             UIViewAutoresizingFlexibleTopMargin |
+                                                             UIViewAutoresizingFlexibleHeight |
+                                                             UIViewAutoresizingFlexibleBottomMargin;
+
 @interface GBInfiniteScrollViewPage ()
 
 @property (nonatomic) GBInfiniteScrollViewPageStyle style;
@@ -84,6 +91,8 @@ CGFloat const GBInfiniteScrollViewPageMargin = 16.0f;
         _contentView.clipsToBounds = YES;
         _contentView.userInteractionEnabled = YES;
         _contentView.exclusiveTouch = YES;
+        _contentView.autoresizesSubviews = YES;
+        _contentView.autoresizingMask = GBInfiniteScrollViewPageResizeAll;
         
         [self addSubview:_contentView];
     }
@@ -95,6 +104,7 @@ CGFloat const GBInfiniteScrollViewPageMargin = 16.0f;
         _textLabel = [[UILabel alloc] initWithFrame:self.bounds];
         
         _textLabel.backgroundColor = [UIColor clearColor];
+        _textLabel.autoresizingMask = GBInfiniteScrollViewPageResizeAll;
         
         if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_6_1) {
             _textLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
@@ -110,6 +120,7 @@ CGFloat const GBInfiniteScrollViewPageMargin = 16.0f;
 {
     if (!_imageView) {
         _imageView = [[UIImageView alloc] initWithFrame:self.bounds];
+        _imageView.autoresizingMask = GBInfiniteScrollViewPageResizeAll;
         
         [_contentView addSubview:_imageView];
     }


### PR DESCRIPTION
While using GBInfiniteScrollView in a universal app, I ran into problems handling rotation. It seemed that pages created in one orientation didn't properly resize once the app had rotated to a different orientation.

In order to fix this problem, I made the following changes:
- GBInfiniteScrollViewPage specifies `autoresizingMasks` for its `contentView`, `imageView`, and `textLabel`
- GBInfiniteScrollView ensures that page frame sizes are set correctly during placement (`placePage:atPointX:`, `placePage:atPointY:`, etc)

The host application still needs to inform GBInfiniteScrollView that the rotation has occurred (ex: by calling `resetLayout` at the appropriate time). In my iOS 8 app, I use:

```
- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
{
    [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
                                                [infiniteScrollView resetLayout];
                                            }
                                 completion:nil];
}
```

Which seems to give the expected results.
