### PR TITLE
Forward UIScrollView delegate methods

### DIFF
--- a/GBInfiniteScrollView/GBInfiniteScrollView/GBInfiniteScrollView.h
+++ b/GBInfiniteScrollView/GBInfiniteScrollView/GBInfiniteScrollView.h
@@ -298,6 +298,26 @@ typedef NS_ENUM(NSInteger, GBScrollDirection) {
 - (void)infiniteScrollView:(GBInfiniteScrollView *)infiniteScrollView didTapAtIndex:(NSInteger)pageIndex;
 
 /**
+ *  Called when the GBInfiniteScrollView will beigin dragging.
+ *
+ *  @warning Optional
+ *
+ *  @param infiniteScrollView Infinite Scroll View Object
+ */
+- (void)infiniteScrollViewWillBeginDragging:(GBInfiniteScrollView *)infiniteScrollView;
+
+/**
+ *  Called when the GBInfiniteScrollView will end dragging.
+ *
+ *  @warning Optional
+ *
+ *  @param infiniteScrollView Infinite Scroll View Object
+ *  @param velocity The velocity of the scroll view (in points) at the moment the touch was released
+ *  @param targetContentOffset The expected offset when the scrolling action decelerates to a stop
+ */
+- (void)infiniteScrollViewWillEndDragging:(GBInfiniteScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset;
+
+/**
  *  Asks the delegate if it is allowed to scroll to next page.
  *
  *  @warning Optional

--- a/GBInfiniteScrollView/GBInfiniteScrollView/Optional/PageControlSubClass/GBInfiniteScrollViewWithPageControl.m
+++ b/GBInfiniteScrollView/GBInfiniteScrollView/Optional/PageControlSubClass/GBInfiniteScrollViewWithPageControl.m
@@ -258,6 +258,15 @@
         NSLog(@"Running %@ '%@'", self.class, NSStringFromSelector(_cmd));
     }
     [self setupPageControl];
+    if ([self.infiniteScrollViewDelegate respondsToSelector:@selector(infiniteScrollViewWillBeginDragging:)]) {
+        [self.infiniteScrollViewDelegate infiniteScrollViewWillBeginDragging:self];
+    }
+}
+
+- (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset {
+    if ([self.infiniteScrollViewDelegate respondsToSelector:@selector(infiniteScrollViewWillEndDragging:withVelocity:targetContentOffset:)]) {
+        [self.infiniteScrollViewDelegate infiniteScrollViewWillEndDragging:self withVelocity:velocity targetContentOffset:targetContentOffset];
+    }
 }
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView

--- a/GBInfiniteScrollViewDemo/GBInfiniteScrollViewDemo.xcodeproj/project.pbxproj
+++ b/GBInfiniteScrollViewDemo/GBInfiniteScrollViewDemo.xcodeproj/project.pbxproj
@@ -530,7 +530,7 @@
 		4300392D187064F600978149 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/GBInfiniteScrollViewDemo.app/GBInfiniteScrollViewDemo";
+				BUNDLE_LOADER = "$(TEST_HOST)";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -544,7 +544,7 @@
 				);
 				INFOPLIST_FILE = "GBInfiniteScrollViewDemoTests/GBInfiniteScrollViewDemoTests-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				TEST_HOST = "$(BUNDLE_LOADER)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Infinite.app/Infinite";
 				WRAPPER_EXTENSION = xctest;
 			};
 			name = Debug;
@@ -552,7 +552,7 @@
 		4300392E187064F600978149 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/GBInfiniteScrollViewDemo.app/GBInfiniteScrollViewDemo";
+				BUNDLE_LOADER = "$(TEST_HOST)";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -562,7 +562,7 @@
 				GCC_PREFIX_HEADER = "GBInfiniteScrollViewDemo/GBInfiniteScrollViewDemo-Prefix.pch";
 				INFOPLIST_FILE = "GBInfiniteScrollViewDemoTests/GBInfiniteScrollViewDemoTests-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				TEST_HOST = "$(BUNDLE_LOADER)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Infinite.app/Infinite";
 				WRAPPER_EXTENSION = xctest;
 			};
 			name = Release;

--- a/GBInfiniteScrollViewPageControlDemo/GBInfiniteScrollViewPageControlDemo/GBViewController.m
+++ b/GBInfiniteScrollViewPageControlDemo/GBInfiniteScrollViewPageControlDemo/GBViewController.m
@@ -417,7 +417,19 @@ static CGFloat const GBGoldenRatio = 0.618033988749895f;
 - (void)infiniteScrollView:(GBInfiniteScrollView *)infiniteScrollView didTapAtIndex:(NSInteger)pageIndex
 {
     if (self.debug) {
-        NSLog(@"Did tap at page %d", pageIndex);
+        NSLog(@"Did tap at page %ld", (long)pageIndex);
+    }
+}
+
+- (void)infiniteScrollViewWillBeginDragging:(GBInfiniteScrollView *)infiniteScrollView {
+    if (self.debug) {
+        NSLog(@"Will begin dragging");
+    }
+}
+
+- (void)infiniteScrollViewWillEndDragging:(GBInfiniteScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset {
+    if (self.debug) {
+        NSLog(@"Will end dragging");
     }
 }
 


### PR DESCRIPTION
One may need to use the UIScrollView's delegate method with GBInfiniteScrollViewWithPageControl outside, but the delegate is currently set to GBInfiniteScrollViewWithPageControl, so I just forward them.