### PR TITLE
run auto scroll timer with NSRunLoopCommonModes

### DIFF
--- a/GBInfiniteScrollView/GBInfiniteScrollView/GBInfiniteScrollView.m
+++ b/GBInfiniteScrollView/GBInfiniteScrollView/GBInfiniteScrollView.m
@@ -492,6 +492,7 @@ static CGFloat const GBAutoScrollDefaultInterval = 3.0f;
                                                         userInfo:nil
                                                          repeats:YES];
         }
+        [[NSRunLoop currentRunLoop] addTimer:self.timer forMode:NSRunLoopCommonModes];
     }
 }
 


### PR DESCRIPTION
use NSRunLoopCommonModes to run autoscroll timer.

"scheduledTimerWithTimeInterval" method schedules the timer with detault mode(NSDefaultRunLoopMode).

the NSDefaultRunLoopMode will affected timer by some touch event.