### PR TITLE
Simultaneously gesture recognizer choice

### DIFF
--- a/GBInfiniteScrollView/GBInfiniteScrollView/GBInfiniteScrollView.h
+++ b/GBInfiniteScrollView/GBInfiniteScrollView/GBInfiniteScrollView.h
@@ -156,8 +156,10 @@ typedef NS_ENUM(NSInteger, GBScrollDirection) {
 @property (nonatomic, getter = isTapEnabled) BOOL tapEnabled;
 
 /**
- *  Whether to use GBInfiniteScrollViews UIPanGestureRecognizer or not. A usage results in a simultaneously gesture recognizer usage!
- *  The default is YES.
+ *  Whether to use GBInfiniteScrollViews UIPanGestureRecognizer or not.
+ *  If enabled, the simultaneously gesture recognizer usage will be enabled.
+ *  This can result in unwanted scroll delegation behavior if you use the GBInfiniteScrollView above other UIScrollViews as the touch input is delegated to these UIScrollViews too.
+ *  Default value YES.
  */
 @property (nonatomic) BOOL useInfiniteScrollPanGestureRecognizer;
 

--- a/GBInfiniteScrollView/GBInfiniteScrollView/GBInfiniteScrollView.h
+++ b/GBInfiniteScrollView/GBInfiniteScrollView/GBInfiniteScrollView.h
@@ -156,6 +156,12 @@ typedef NS_ENUM(NSInteger, GBScrollDirection) {
 @property (nonatomic, getter = isTapEnabled) BOOL tapEnabled;
 
 /**
+ *  Whether to use GBInfiniteScrollViews UIPanGestureRecognizer or not. A usage results in a simultaneously gesture recognizer usage!
+ *  The default is YES.
+ */
+@property (nonatomic) BOOL useInfiniteScrollPanGestureRecognizer;
+
+/**
  *  Gets the current view.
  *
  *  @return The current page of the infinite scroll view.

--- a/GBInfiniteScrollView/GBInfiniteScrollView/GBInfiniteScrollView.m
+++ b/GBInfiniteScrollView/GBInfiniteScrollView/GBInfiniteScrollView.m
@@ -530,11 +530,14 @@ static CGFloat const GBAutoScrollDefaultInterval = 3.0f;
     [self setupTapGesture];
 }
 
-- (void)setUseInfiniteScrollPanGestureRecognizer:(BOOL)useInfiniteScrollPanGestureRecognizer {
+- (void)setUseInfiniteScrollPanGestureRecognizer:(BOOL)useInfiniteScrollPanGestureRecognizer
+{
     _useInfiniteScrollPanGestureRecognizer = useInfiniteScrollPanGestureRecognizer;
     
     if (self.useInfiniteScrollPanGestureRecognizer) {
-        if (self.infiniteScrollViewPanGestureRecognizer == nil) [self setupPanGesture];
+        if (self.infiniteScrollViewPanGestureRecognizer == nil) {
+           [self setupPanGesture];
+        }
     } else {
         [self removeGestureRecognizer:self.infiniteScrollViewPanGestureRecognizer];
         self.infiniteScrollViewPanGestureRecognizer = nil;
@@ -1805,7 +1808,7 @@ static CGFloat const GBAutoScrollDefaultInterval = 3.0f;
 
 -(BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
 {
-    //If the usage of the PanGestureRecognizer is enabled, we need to enable simultaneously gesture recongizing. If not, it's not needed.
+    //If the usage of the UIPanGestureRecognizer is enabled, we need to enable simultaneously gesture recognizing. If not, it's not needed.
     return self.useInfiniteScrollPanGestureRecognizer;
 }
 

--- a/GBInfiniteScrollView/GBInfiniteScrollView/GBInfiniteScrollView.m
+++ b/GBInfiniteScrollView/GBInfiniteScrollView/GBInfiniteScrollView.m
@@ -341,6 +341,8 @@ static CGFloat const GBAutoScrollDefaultInterval = 3.0f;
  */
 @property (nonatomic) BOOL shouldScrollPreviousPage;
 
+@property (nonatomic, strong) UIPanGestureRecognizer *infiniteScrollViewPanGestureRecognizer;
+
 
 @property (nonatomic) BOOL needsUpdatePageIndex;
 @property (nonatomic) NSUInteger newPageIndex;
@@ -434,11 +436,7 @@ static CGFloat const GBAutoScrollDefaultInterval = 3.0f;
     self.showsHorizontalScrollIndicator = NO;
     self.showsVerticalScrollIndicator = NO;
     self.userInteractionEnabled = YES;
-    
-    UIPanGestureRecognizer *pan = [[UIPanGestureRecognizer alloc]initWithTarget:self
-                                                                         action:@selector(panOnScrollView:)];
-    pan.delegate = self;
-    [self addGestureRecognizer:pan];
+    self.useInfiniteScrollPanGestureRecognizer = YES;
     
     [self setupTapGesture];
     
@@ -460,6 +458,20 @@ static CGFloat const GBAutoScrollDefaultInterval = 3.0f;
         [self addGestureRecognizer:gesture];
     } else {
         self.exclusiveTouch = NO;
+    }
+}
+
+- (void)setupPanGesture
+{
+    if (self.isDebugModeOn && self.isVerboseDebugModeOn) {
+        NSLog(@"Running %@ '%@'", self.class, NSStringFromSelector(_cmd));
+    }
+    
+    if (self.useInfiniteScrollPanGestureRecognizer) {
+        self.infiniteScrollViewPanGestureRecognizer = [[UIPanGestureRecognizer alloc]initWithTarget:self
+                                                                                             action:@selector(panOnScrollView:)];
+        self.infiniteScrollViewPanGestureRecognizer.delegate = self;
+        [self addGestureRecognizer:self.infiniteScrollViewPanGestureRecognizer];
     }
 }
 
@@ -516,6 +528,17 @@ static CGFloat const GBAutoScrollDefaultInterval = 3.0f;
 - (void)setTapEnabled:(BOOL)tapEnabled {
     _tapEnabled = tapEnabled;
     [self setupTapGesture];
+}
+
+- (void)setUseInfiniteScrollPanGestureRecognizer:(BOOL)useInfiniteScrollPanGestureRecognizer {
+    _useInfiniteScrollPanGestureRecognizer = useInfiniteScrollPanGestureRecognizer;
+    
+    if (self.useInfiniteScrollPanGestureRecognizer) {
+        if (self.infiniteScrollViewPanGestureRecognizer == nil) [self setupPanGesture];
+    } else {
+        [self removeGestureRecognizer:self.infiniteScrollViewPanGestureRecognizer];
+        self.infiniteScrollViewPanGestureRecognizer = nil;
+    }
 }
 
 #pragma mark - Tap
@@ -1782,7 +1805,8 @@ static CGFloat const GBAutoScrollDefaultInterval = 3.0f;
 
 -(BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
 {
-    return YES;
+    //If the usage of the PanGestureRecognizer is enabled, we need to enable simultaneously gesture recongizing. If not, it's not needed.
+    return self.useInfiniteScrollPanGestureRecognizer;
 }
 
 


### PR DESCRIPTION
I added the option to deactivate the UIPanGestureRecognizer usage. 

This is needed for the project I'm working on as we are using the GBInfiniteScrollView inside a UICollectionViewCell. With the introduction of the UIPanGestureRecognizer callback, "shouldRecognizeSimultaneouslyWithGestureRecognizer:" was added with the hardcoded return value "YES". As the simultaneously gesture recognising is enabled, the UICollectionView consumes the touch input as well as the GBInfiniteScrollView. This results in unwanted scrolling behaviour in our setup.